### PR TITLE
Switch from Star to a minimal install of Rakudo on debian:bullseye-slim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cro Dockerfiles
 
-These `Dockerfile`s define images that may be used when deploying services
-built with [Cro](http://cro.services/). They are based on a recent [Rakudo
-Star image](https://hub.docker.com/_/rakudo-star/).
+These `Dockerfile`s define images that may be used when deploying services built with [Cro](http://cro.services/). They are based on the Debian `bullseye-slim` image, with build of Rakudo with only Cro's dependencies installed.
+
+Until Cro version 0.8.7, images were built based on a Rakudo Star image, and hence shipped with many more modules. Beware that if you are upgrading from the Rakudo Star based images, you may well need to change your own `Dockerfile`s to install modules that Star bundled, but are no longer in these images.

--- a/bullseye-rakudo-zef/Dockerfile
+++ b/bullseye-rakudo-zef/Dockerfile
@@ -1,0 +1,53 @@
+### Dockerfile for building a minimal rakudo with zef
+
+# use base image.
+FROM debian:bullseye-slim AS build
+
+# Author
+MAINTAINER Nicholas Clark <nick@ccl4.org>
+
+ARG rakudo_version=2021.10
+ARG zef_version=v0.13.4
+ARG prefix=/opt/rakudo
+
+ARG keep="ca-certificates"
+ARG build_only="build-essential git"
+
+# The update-ca-certificates might be cargo-cult.
+# Installing ca-certificates is not.
+
+ENV PATH=${prefix}/share/perl6/site/bin:${prefix}/share/perl6/core/bin:${prefix}/bin:$PATH
+
+RUN \
+  apt-get update && \
+  apt-get --yes --no-install-recommends install ${keep} ${build_only} && \
+  update-ca-certificates && \
+  git config --global advice.detachedHead false && \
+  tmpdir="$(mktemp -d)" && \
+  cd ${tmpdir} && \
+  git clone --depth=1 --shallow-submodules --branch ${rakudo_version} https://github.com/MoarVM/MoarVM && \
+  cd MoarVM && \
+  ./Configure.pl --prefix=${prefix} && \
+  make -j3 install && \
+  tmpdir="$(mktemp -d)" && \
+  cd ${tmpdir} && \
+  git clone --depth=1 --shallow-submodules --branch ${rakudo_version} https://github.com/Raku/nqp && \
+  cd nqp && \
+  ./Configure.pl --prefix=${prefix} && \
+  make -j3 test install && \
+  tmpdir="$(mktemp -d)" && \
+  cd ${tmpdir} && \
+  git clone --depth=1 --shallow-submodules --branch ${rakudo_version} https://github.com/rakudo/rakudo && \
+  cd rakudo && \
+  ./Configure.pl --prefix=${prefix} && \
+  make -j3 test install HARNESS_TYPE=6 && \
+  tmpdir="$(mktemp -d)" && \
+  cd ${tmpdir} && \
+  git clone --depth=1  --branch ${zef_version} https://github.com/ugexe/zef && \
+  cd zef && \
+  rakudo -I. bin/zef install . && \
+  apt-get purge -y --auto-remove ${build_only} && \
+  rm -rf /var/lib/apt/lists/*
+
+# Run when the container launches
+CMD ["/opt/rakudo/bin/rakudo"]

--- a/cro-core/Dockerfile
+++ b/cro-core/Dockerfile
@@ -1,6 +1,10 @@
-FROM rakudo-star:2020.01
+FROM bullseye-rakudo-zef:2021-10
 MAINTAINER Jonathan Worthington <jonathan@edument.se>
 
 ARG cro_version=0.8.7
 
-RUN zef install 'Cro::Core:ver<'$cro_version'>'
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install curl && \
+    zef install 'Cro::Core:ver<'$cro_version'>' && \
+    apt-get purge -y --auto-remove curl && \
+    rm -rf /var/lib/apt/lists/*

--- a/cro-http-websocket/Dockerfile
+++ b/cro-http-websocket/Dockerfile
@@ -1,14 +1,17 @@
-FROM rakudo-star:2020.01
+FROM bullseye-rakudo-zef:2021-10
 MAINTAINER Jonathan Worthington <jonathan@edument.se>
 
 ARG cro_version=0.8.7
 
+ARG keep="libssl-dev"
+ARG build_only="build-essential curl git"
+
 RUN apt-get update && \
-    apt-get --yes --no-install-recommends install libssl-dev build-essential && \
-    zef upgrade OpenSSL && \
+    apt-get --yes --no-install-recommends install ${keep} ${build_only} && \
+    zef install OpenSSL && \
     zef install 'Cro::Core:ver<'$cro_version'>' && \
     zef install 'Cro::TLS:ver<'$cro_version'>' && \
     zef install 'Cro::HTTP:ver<'$cro_version'>' && \
     zef install 'Cro::WebSocket:ver<'$cro_version'>' && \
-    apt-get purge -y --auto-remove build-essential && \
+    apt-get purge -y --auto-remove ${build_only} && \
     rm -rf /var/lib/apt/lists/*

--- a/cro-http/Dockerfile
+++ b/cro-http/Dockerfile
@@ -1,12 +1,16 @@
-FROM rakudo-star:2020.01
+FROM bullseye-rakudo-zef:2021-10
 MAINTAINER Jonathan Worthington <jonathan@edument.se>
 
 ARG cro_version=0.8.7
 
+ARG keep="libssl-dev"
+ARG build_only="curl git"
+
 RUN apt-get update && \
-    apt-get --yes --no-install-recommends install libssl-dev && \
-    rm -rf /var/lib/apt/lists/* && \
-    zef upgrade OpenSSL && \
+    apt-get --yes --no-install-recommends install ${keep} ${build_only} && \
+    zef install OpenSSL && \
     zef install 'Cro::Core:ver<'$cro_version'>' && \
     zef install 'Cro::TLS:ver<'$cro_version'>' && \
-    zef install 'Cro::HTTP:ver<'$cro_version'>'
+    zef install 'Cro::HTTP:ver<'$cro_version'>' && \
+    apt-get purge -y --auto-remove ${build_only} && \
+    rm -rf /var/lib/apt/lists/*

--- a/cro/Dockerfile
+++ b/cro/Dockerfile
@@ -1,15 +1,16 @@
-FROM rakudo-star:2020.01
+FROM bullseye-rakudo-zef:2021-10
 MAINTAINER Jonathan Worthington <jonathan@edument.se>
 
-ARG cro_version=0.8.7
+ARG keep="libssl-dev"
+ARG build_only="build-essential curl git"
 
 RUN apt-get update && \
-    apt-get --yes --no-install-recommends install libssl-dev build-essential && \
-    zef upgrade OpenSSL && \
+    apt-get --yes --no-install-recommends install ${keep} ${build_only} && \
+    zef install OpenSSL && \
     zef install 'Cro::Core:ver<'$cro_version'>' && \
     zef install 'Cro::TLS:ver<'$cro_version'>' && \
     zef install 'Cro::HTTP:ver<'$cro_version'>' && \
     zef install 'Cro::WebSocket:ver<'$cro_version'>' && \
     zef install 'cro:ver<'$cro_version'>' && \
-    apt-get purge -y --auto-remove build-essential && \
+    apt-get purge -y --auto-remove ${build_only} && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This represents several breaking changes at the same time

1) Only install Cro's minimal dependencies.
   Previously using Rakudo Star meant that we shipped other (useful) modules
2) We now build on bullseye-slim.
   Star was building on buster, and with more Debian packages installed
3) We now install to /opt/rakudo/bin (etc)
   The Rakudo Star docker image is built with a prefix of /usr

The docker image is still built with a `PATH` that contains rakudo, zef and the other relevant binaries.

The Rakudo version of 2021.10 is quite a jump - Cro was using Rakudo Star from 2020.01. The latest Star is 2021.04, but @jnthn reports that it isn't really suitable as the the version of OpenSSL that it bundles has bugs that aren't easy to work around. As 2021.04 is already 6 months old, bite the bullet and move to the most recent monthly release.

Given the other breaking changes that end users will have to evaluate here, I don't think that it adds cost to change the `PATH` that we install to. Star's `Dockerfile` is written to build with a `--prefix` of `/usr`. Long term, I don't think that that's wise. In that, I hope we soon see end user tools written in Raku, **and** then Debian (and other distros) package them, at which point the OS would want to install **its** `rakudo` package to `/usr/bin`, and that would clash with one we installed, if we keep installing there. Hence as this is already a "flag day" commit, we can add more flags for little extra cost.